### PR TITLE
Support different input bindings

### DIFF
--- a/lib/examples/component-with-bindings.spec.ts
+++ b/lib/examples/component-with-bindings.spec.ts
@@ -18,7 +18,7 @@ interface Person {
   `,
 })
 class BornInComponent implements OnChanges {
-  @Input() person!: Person;
+  @Input({ required: true }) person!: Person;
   @Output() selected = new EventEmitter<Person>();
 
   public ngOnChangesCount = 0;

--- a/lib/examples/component-with-bindings.spec.ts
+++ b/lib/examples/component-with-bindings.spec.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, NgModule, OnChanges, Output } from '@angular/core';
+import { Component, EventEmitter, input, Input,NgModule, OnChanges, Output } from '@angular/core';
 import { Shallow } from '../shallow';
 
 ////// Module Setup //////
@@ -14,11 +14,15 @@ interface Person {
     <label id="personLabel" (click)="selected.emit(person)">
       {{ person.firstName }} {{ person.lastName }} was born in {{ person.birthDate.getFullYear() }}
     </label>
+    <label id="partnerLabel" (click)="selected.emit(partner())">
+      {{ partner().firstName }} {{ partner().lastName }} was born in {{ partner().birthDate.getFullYear() }}
+    </label>
     <label id="ngOnChangesCount">{{ ngOnChangesCount }}</label>
   `,
 })
 class BornInComponent implements OnChanges {
   @Input({ required: true }) person!: Person;
+  partner =  input.required<Person>();
   @Output() selected = new EventEmitter<Person>();
 
   public ngOnChangesCount = 0;
@@ -47,21 +51,35 @@ describe('component with bindings', () => {
     birthDate: new Date('1982-05-11'),
   };
 
+  const partner: Person = {
+    firstName: 'John',
+    lastName: 'Doe',
+    birthDate: new Date('1990-01-12'),
+  };
+
   it('displays the name and year the person was born', async () => {
-    const { find } = await shallow.render({ bind: { person } });
+    const { find } = await shallow.render({ bind: { person, partner } });
 
     expect(find('#personLabel').nativeElement.textContent).toContain('Brandon Domingue was born in 1982');
+    expect(find('#partnerLabel').nativeElement.textContent).toContain('John Doe was born in 1990');
   });
 
   it('emits the person when clicked', async () => {
-    const { find, outputs } = await shallow.render({ bind: { person } });
+    const { find, outputs } = await shallow.render({ bind: { person, partner }});
     find('#personLabel').nativeElement.click();
 
     expect(outputs.selected.emit).toHaveBeenCalledWith(person);
   });
 
+  it('emits the partner when clicked', async () => {
+    const { find, outputs } = await shallow.render({ bind: { person, partner }});
+    find('#partnerLabel').nativeElement.click();
+
+    expect(outputs.selected.emit).toHaveBeenCalledWith(partner);
+  });
+
   it('displays the number of times the person was updated', async () => {
-    const { find, fixture, bindings } = await shallow.render({ bind: { person } });
+    const { find, fixture, bindings } = await shallow.render({ bind: { person, partner }});
 
     expect(find('#ngOnChangesCount').nativeElement.textContent).toBe('1');
 
@@ -70,4 +88,10 @@ describe('component with bindings', () => {
 
     expect(find('#ngOnChangesCount').nativeElement.textContent).toBe('2');
   });
+
+  it('throws for missing required input signal', async  () => {
+    await expect(shallow.render({ bind: { person } }))
+      .rejects.toThrow('Input is required but no value is available yet.');
+  });
+
 });

--- a/lib/examples/component-with-bindings.spec.ts
+++ b/lib/examples/component-with-bindings.spec.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, input, Input,NgModule, OnChanges, Output } from '@angular/core';
+import { Component, EventEmitter, input, Input, NgModule, OnChanges, Output } from '@angular/core';
 import { Shallow } from '../shallow';
 
 ////// Module Setup //////
@@ -22,7 +22,7 @@ interface Person {
 })
 class BornInComponent implements OnChanges {
   @Input({ required: true }) person!: Person;
-  partner =  input.required<Person>();
+  partner = input.required<Person>();
   @Output() selected = new EventEmitter<Person>();
 
   public ngOnChangesCount = 0;
@@ -65,21 +65,21 @@ describe('component with bindings', () => {
   });
 
   it('emits the person when clicked', async () => {
-    const { find, outputs } = await shallow.render({ bind: { person, partner }});
+    const { find, outputs } = await shallow.render({ bind: { person, partner } });
     find('#personLabel').nativeElement.click();
 
     expect(outputs.selected.emit).toHaveBeenCalledWith(person);
   });
 
   it('emits the partner when clicked', async () => {
-    const { find, outputs } = await shallow.render({ bind: { person, partner }});
+    const { find, outputs } = await shallow.render({ bind: { person, partner } });
     find('#partnerLabel').nativeElement.click();
 
     expect(outputs.selected.emit).toHaveBeenCalledWith(partner);
   });
 
   it('displays the number of times the person was updated', async () => {
-    const { find, fixture, bindings } = await shallow.render({ bind: { person, partner }});
+    const { find, fixture, bindings } = await shallow.render({ bind: { person, partner } });
 
     expect(find('#ngOnChangesCount').nativeElement.textContent).toBe('1');
 
@@ -89,9 +89,9 @@ describe('component with bindings', () => {
     expect(find('#ngOnChangesCount').nativeElement.textContent).toBe('2');
   });
 
-  it('throws for missing required input signal', async  () => {
-    await expect(shallow.render({ bind: { person } }))
-      .rejects.toThrow('Input is required but no value is available yet.');
+  it('throws for missing required input signal', async () => {
+    await expect(shallow.render({ bind: { person } })).rejects.toThrow(
+      'Input is required but no value is available yet.',
+    );
   });
-
 });

--- a/lib/models/recursive-partial.ts
+++ b/lib/models/recursive-partial.ts
@@ -2,10 +2,15 @@
  * Utility type that converts an object to recursively have optional properties.
  * This includes items an arrays and return values for functions.
  */
+import { InputSignal } from '@angular/core';
+
 export type RecursivePartial<T> = Partial<{
-  [key in keyof T]: T[key] extends (...a: Array<infer U>) => any
-    ? (...a: Array<U>) => RecursivePartial<ReturnType<T[key]>> | ReturnType<T[key]>
-    : T[key] extends Array<any>
-      ? Array<RecursivePartial<T[key][number]>>
-      : RecursivePartial<T[key]> | T[key];
+  [key in keyof T]:
+  T[key] extends InputSignal<infer U>  // Handle signals like input() and input.required()
+    ? RecursivePartial<U>  // Extract the type and recursively apply RecursivePartial
+    : T[key] extends (...a: Array<infer U>) => any // Function-based properties (like methods or other signals)
+      ? (...a: Array<U>) => RecursivePartial<ReturnType<T[key]>> | ReturnType<T[key]>
+      : T[key] extends Array<any> // Handle array types
+        ? Array<RecursivePartial<T[key][number]>>
+        : RecursivePartial<T[key]> | T[key]; // Handle other standard cases
 }>;

--- a/lib/models/recursive-partial.ts
+++ b/lib/models/recursive-partial.ts
@@ -5,9 +5,8 @@
 import { InputSignal } from '@angular/core';
 
 export type RecursivePartial<T> = Partial<{
-  [key in keyof T]:
-  T[key] extends InputSignal<infer U>  // Handle signals like input() and input.required()
-    ? RecursivePartial<U>  // Extract the type and recursively apply RecursivePartial
+  [key in keyof T]: T[key] extends InputSignal<infer U> // Handle signals like input() and input.required()
+    ? RecursivePartial<U> // Extract the type and recursively apply RecursivePartial
     : T[key] extends (...a: Array<infer U>) => any // Function-based properties (like methods or other signals)
       ? (...a: Array<U>) => RecursivePartial<ReturnType<T[key]>> | ReturnType<T[key]>
       : T[key] extends Array<any> // Handle array types

--- a/lib/tools/reflect.spec.ts
+++ b/lib/tools/reflect.spec.ts
@@ -86,11 +86,15 @@ describe('reflect', () => {
       @Component({ selector: 'my-component', template: '<div></div>' })
       class TestComponent {
         @Input() myInput!: string;
+        @Input({required: true}) myRequiredInput!: string;
         @Output() myOutput = new EventEmitter<string>();
       }
 
       expect(reflect.getInputsAndOutputs(TestComponent)).toEqual({
-        inputs: [{ alias: 'myInput', propertyName: 'myInput' }],
+        inputs: [
+          { alias: 'myInput', propertyName: 'myInput' },
+          { alias: 'myRequiredInput', propertyName: 'myRequiredInput' }
+        ],
         outputs: [{ alias: 'myOutput', propertyName: 'myOutput' }],
       });
     });
@@ -122,11 +126,15 @@ describe('reflect', () => {
       @Component({ selector: 'my-component', template: '<div></div>' })
       class TestComponent {
         @Input('inputAlias') myInput!: string;
+        @Input({alias: 'requiredInputAlias', required: true}) myRequiredInput!: string;
         @Output('outputAlias') myOutput = new EventEmitter<string>();
       }
 
       expect(reflect.getInputsAndOutputs(TestComponent)).toEqual({
-        inputs: [{ alias: 'inputAlias', propertyName: 'myInput' }],
+        inputs: [
+          { alias: 'inputAlias', propertyName: 'myInput' },
+          { alias: 'requiredInputAlias', propertyName: 'myRequiredInput' }
+        ],
         outputs: [{ alias: 'outputAlias', propertyName: 'myOutput' }],
       });
     });

--- a/lib/tools/reflect.spec.ts
+++ b/lib/tools/reflect.spec.ts
@@ -1,6 +1,17 @@
 /* eslint-disable @angular-eslint/no-outputs-metadata-property */
 /* eslint-disable @angular-eslint/no-inputs-metadata-property */
-import { Component, Directive, EventEmitter, Input, NgModule, Output, Pipe, PipeTransform } from '@angular/core';
+import {
+  Component,
+  Directive,
+  EventEmitter,
+  Input,
+  NgModule,
+  Output,
+  Pipe,
+  PipeTransform,
+  input,
+  output,
+} from '@angular/core';
 import { reflect } from './reflect';
 describe('reflect', () => {
   @Directive({ selector: 'foo-directive' })
@@ -88,6 +99,23 @@ describe('reflect', () => {
         @Input() myInput!: string;
         @Input({required: true}) myRequiredInput!: string;
         @Output() myOutput = new EventEmitter<string>();
+      }
+
+      expect(reflect.getInputsAndOutputs(TestComponent)).toEqual({
+        inputs: [
+          { alias: 'myInput', propertyName: 'myInput' },
+          { alias: 'myRequiredInput', propertyName: 'myRequiredInput' }
+        ],
+        outputs: [{ alias: 'myOutput', propertyName: 'myOutput' }],
+      });
+    });
+
+    it('gets signal inputs and outputs', () => {
+      @Component({ selector: 'my-component', template: '<div></div>' })
+      class TestComponent {
+        myInput = input<string>();
+        myRequiredInput = input.required<string>();
+       myOutput = output<string>();
       }
 
       expect(reflect.getInputsAndOutputs(TestComponent)).toEqual({

--- a/lib/tools/reflect.spec.ts
+++ b/lib/tools/reflect.spec.ts
@@ -97,14 +97,14 @@ describe('reflect', () => {
       @Component({ selector: 'my-component', template: '<div></div>' })
       class TestComponent {
         @Input() myInput!: string;
-        @Input({required: true}) myRequiredInput!: string;
+        @Input({ required: true }) myRequiredInput!: string;
         @Output() myOutput = new EventEmitter<string>();
       }
 
       expect(reflect.getInputsAndOutputs(TestComponent)).toEqual({
         inputs: [
           { alias: 'myInput', propertyName: 'myInput' },
-          { alias: 'myRequiredInput', propertyName: 'myRequiredInput' }
+          { alias: 'myRequiredInput', propertyName: 'myRequiredInput' },
         ],
         outputs: [{ alias: 'myOutput', propertyName: 'myOutput' }],
       });
@@ -115,13 +115,13 @@ describe('reflect', () => {
       class TestComponent {
         myInput = input<string>();
         myRequiredInput = input.required<string>();
-       myOutput = output<string>();
+        myOutput = output<string>();
       }
 
       expect(reflect.getInputsAndOutputs(TestComponent)).toEqual({
         inputs: [
           { alias: 'myInput', propertyName: 'myInput' },
-          { alias: 'myRequiredInput', propertyName: 'myRequiredInput' }
+          { alias: 'myRequiredInput', propertyName: 'myRequiredInput' },
         ],
         outputs: [{ alias: 'myOutput', propertyName: 'myOutput' }],
       });
@@ -154,14 +154,14 @@ describe('reflect', () => {
       @Component({ selector: 'my-component', template: '<div></div>' })
       class TestComponent {
         @Input('inputAlias') myInput!: string;
-        @Input({alias: 'requiredInputAlias', required: true}) myRequiredInput!: string;
+        @Input({ alias: 'requiredInputAlias', required: true }) myRequiredInput!: string;
         @Output('outputAlias') myOutput = new EventEmitter<string>();
       }
 
       expect(reflect.getInputsAndOutputs(TestComponent)).toEqual({
         inputs: [
           { alias: 'inputAlias', propertyName: 'myInput' },
-          { alias: 'requiredInputAlias', propertyName: 'myRequiredInput' }
+          { alias: 'requiredInputAlias', propertyName: 'myRequiredInput' },
         ],
         outputs: [{ alias: 'outputAlias', propertyName: 'myOutput' }],
       });

--- a/lib/tools/reflect.ts
+++ b/lib/tools/reflect.ts
@@ -91,13 +91,24 @@ export const reflect = {
       };
     while ((currentComponent = Object.getPrototypeOf(currentComponent)) && typeof currentComponent === 'function');
 
+    const getAlias = (input: { type: any; args?: any[] }, key: string) => {
+      const firstArg = input.args?.[0];
+      if (!firstArg) {
+        return key
+      }
+      if (typeof firstArg === "string") {
+        return firstArg;
+      }
+      return firstArg?.alias || key;
+    }
+
     return Object.entries(propDecorators).reduce<InputsAndOutputs>(
       (acc, [key, value]) => {
         const input = value.find(v => v.type === Input);
         if (input) {
           return {
             ...acc,
-            inputs: [...acc.inputs, { propertyName: key, alias: input.args?.[0] || key }],
+            inputs: [...acc.inputs, { propertyName: key, alias: getAlias(input, key) }],
           };
         }
 
@@ -105,7 +116,7 @@ export const reflect = {
         if (output) {
           return {
             ...acc,
-            outputs: [...acc.outputs, { propertyName: key, alias: output.args?.[0] || key }],
+            outputs: [...acc.outputs, { propertyName: key, alias: getAlias(output, key) }],
           };
         }
         return acc;

--- a/lib/tools/reflect.ts
+++ b/lib/tools/reflect.ts
@@ -94,13 +94,13 @@ export const reflect = {
     const getAlias = (input: { type: any; args?: any[] }, key: string) => {
       const firstArg = input.args?.[0];
       if (!firstArg) {
-        return key
+        return key;
       }
-      if (typeof firstArg === "string") {
+      if (typeof firstArg === 'string') {
         return firstArg;
       }
       return firstArg?.alias || key;
-    }
+    };
 
     return Object.entries(propDecorators).reduce<InputsAndOutputs>(
       (acc, [key, value]) => {


### PR DESCRIPTION
This PR addresses the issue outlined in [#255](https://github.com/getsaf/shallow-render/issues/255).


**Key Changes:**
Support for @Input() with InputOption (e.g. `Input({required: true})`: This change enables shallow-render to handle components that use @Input() decorated properties with InputOptions, expanding the ability to mock and manipulate inputs in tests.

Support for Input Signals: Input signals are now also supported in the shallow rendering of components, providing further flexibility in simulating and testing input changes.


